### PR TITLE
draw_tui() now clears screen before drawing

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -11,6 +11,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <cstdlib>
+#define clrscr() system("cls")
+#else
+// Requires stdio.h (already included)
+#define clrscr() printf(/* clear sequence for ANSI terminals*/ "\e[1;1H\e[2J")
+#endif
+
 bool breakpoint_encountered = true;
 bool step_into_activated = false;
 bool isr_active = false;
@@ -461,6 +469,7 @@ bool draw_tui(void) {
     return false;
   }
 
+  clrscr();
   printf("%s\n", create_heading('-', "Registers", LINEWIDTH));
   print_array_with_idcs(REGS, NUM_REGISTERS, false);
 


### PR DESCRIPTION
Terminal is cleared using an ANSI escape sequence before drawing the UI (UNIX only). This increases readability of the debug mode and makes the UI way better, even without ncurses (I've seen the commented prototype).
Windows systems use the "cls" command. Only tested under Linux, as I do not use Windows. Windows should work as well but a Windows user might test it first anyways before merging with the main branch.